### PR TITLE
Better cache query

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 description "RF Dashboard app for CEBAF"
 group 'org.jlab'
 version '2.0.2'
-ext.releaseDate = 'July 26, 2023'
+ext.releaseDate = 'July 30, 2023'
 ext.resourceNumber = '42'
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ plugins {
 
 description "RF Dashboard app for CEBAF"
 group 'org.jlab'
-version '2.0.2'
+version '2.1.0'
 ext.releaseDate = 'July 30, 2023'
-ext.resourceNumber = '42'
+ext.resourceNumber = '43'
 
 tasks.withType(JavaCompile) {
     options.release = 11

--- a/docker/oracle/setup/02_create_tables.sql
+++ b/docker/oracle/setup/02_create_tables.sql
@@ -179,7 +179,7 @@ CREATE TABLE rfgradteam_owner.cavity_cache (
        QUERY_DATE                 DATE            NOT NULL,
        CAVITY_NAME                VARCHAR2(32)    NOT NULL,
        EPICS_NAME                 VARCHAR2(2048)  NOT NULL,
-       MOD_ANODE_VOLTAGE          NUMBER(10, 6)   NOT NULL,
+       MOD_ANODE_VOLTAGE          NUMBER(10, 6),
        CRYOMODULE_TYPE            VARCHAR2(2048)  NOT NULL,
        GSET                       NUMBER(10, 6),
        ODVH                       NUMBER(10, 6),

--- a/scripts/sql/add_cavity_cache.sql
+++ b/scripts/sql/add_cavity_cache.sql
@@ -11,7 +11,7 @@ CREATE TABLE rfgradteam_owner.cavity_cache (
                                                QUERY_DATE                 DATE            NOT NULL,
                                                CAVITY_NAME                VARCHAR2(32)    NOT NULL,
                                                EPICS_NAME                 VARCHAR2(2048)  NOT NULL,
-                                               MOD_ANODE_VOLTAGE          NUMBER(10, 6)   NOT NULL,
+                                               MOD_ANODE_VOLTAGE          NUMBER(10, 6),
                                                CRYOMODULE_TYPE            VARCHAR2(2048)  NOT NULL,
                                                GSET                       NUMBER(10, 6),
                                                ODVH                       NUMBER(10, 6),

--- a/src/integration/java/org/jlab/rfd/presentation/controller/ajax/CavityAjaxTest.java
+++ b/src/integration/java/org/jlab/rfd/presentation/controller/ajax/CavityAjaxTest.java
@@ -164,4 +164,36 @@ public class CavityAjaxTest {
     public void testBadOut() {
         Assert.assertThrows(IOException.class, this::throwBadOut);
     }
+
+     @Test
+    public void testCacheSpeed() throws IOException {
+
+        String query = "?t=day" +
+                "&date=2022-02-01" +
+                "&date=2022-02-02" +
+                "&date=2022-02-03" +
+                "&date=2022-02-04" +
+                "&date=2022-02-05" +
+                "&date=2022-02-06" +
+                "&date=2022-02-07" +
+                "&out=json";
+
+        System.out.println("Making query - make take time since some data likely is not cached.");
+        JsonObject json = makeQuery(query);
+        JsonArray data = json.getJsonArray("data");
+
+        Date start, end;
+        double duration;
+        for (int i = 0; i < 5; i++) {
+            start = new Date();
+            json = makeQuery(query);
+            data = json.getJsonArray("data");
+            end = new Date();
+            duration = (end.getTime() - start.getTime()) / 1000.0;
+            System.out.println("Query took " + duration + " seconds");
+        }
+
+        // Make sure we got something
+        Assert.assertEquals(7, data.size());
+    }
 }

--- a/src/integration/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjaxTest.java
+++ b/src/integration/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjaxTest.java
@@ -1,0 +1,92 @@
+package org.jlab.rfd.presentation.controller.ajax;
+
+import org.jlab.rfd.business.util.DateUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.io.*;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Date;
+
+public class ModAnodeAjaxTest {
+
+    static final String CAVITY_CACHE_URL = "http://localhost:8080/RFDashboard/ajax/cavity-cache";
+    private static final String MOD_ANODE_URL = "http://localhost:8080/RFDashboard/ajax/mod-anode";
+    private JsonObject makeQuery(String query) throws IOException {
+        JsonObject json;
+        URL url = new URL(MOD_ANODE_URL + query);
+        InputStream is = url.openStream();
+
+        try (JsonReader reader = Json.createReader(is)) {
+            json = reader.readObject();
+        }
+        return json;
+    }
+
+    private void clearCache(Date date) throws IOException {
+        JsonObject json;
+        URL url = new URL(CAVITY_CACHE_URL + "?date=" + DateUtil.formatDateYMD(date) + "&secret=ayqs&action=clear");
+        InputStream is = url.openStream();
+        try (JsonReader reader = Json.createReader(is)) {
+            json = reader.readObject();
+        }
+        if (json.get("rowsCleared") == null) {
+            throw new RuntimeException(("Error processing cache clear response"));
+        }
+    }
+    @Test
+    public void testBasicUsageCEDData () throws IOException {
+        String query = "?start=2021-12-15&end=2021-12-17&timeUnit=day";
+        String expString = "{" +
+                "\"labels\":[\"Injector\",\"North\",\"South\",\"Total\"]," +
+                "\"data\":[" +
+                "[[1639526400000,\"0\"],[1639612800000,\"0\"],[1639699200000,\"0\"]]," +
+                "[[1639526400000,\"20\"],[1639612800000,\"20\"],[1639699200000,\"20\"]]," +
+                "[[1639526400000,\"43\"],[1639612800000,\"43\"],[1639699200000,\"43\"]]," +
+                "[[1639526400000,\"63\"],[1639612800000,\"63\"],[1639699200000,\"63\"]]" +
+                "]" +
+                "}";
+        JsonObject exp;
+        try (JsonReader reader = Json.createReader(new StringReader(expString))) {
+            exp = reader.readObject();
+        }
+
+        JsonObject res = makeQuery(query);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void testBasicUsageMYAData () throws IOException, ParseException {
+        String d = "2022-03-15";
+        Date date = DateUtil.parseDateStringYMD(d);
+        clearCache(date);
+        String query = "?start=" + d + "&end=" + d + "&timeUnit=day";
+        String expString = "{" +
+                "\"labels\":[\"Injector\",\"North\",\"South\",\"Total\",\"Unknown\"]," +
+                "\"data\":[" +
+                "[[1647302400000,\"0\"]]," +
+                "[[1647302400000,\"18\"]]," +
+                "[[1647302400000,\"42\"]]," +
+                "[[1647302400000,\"60\"]]," +
+                "[[1647302400000,\"42\"]]" +
+                "]" +
+                "}";
+        JsonObject exp;
+        try (JsonReader reader = Json.createReader(new StringReader(expString))) {
+            exp = reader.readObject();
+        }
+
+        // Check without the cache
+        JsonObject res = makeQuery(query);
+        Assert.assertEquals(exp, res);
+
+        // Check with cache
+        res = makeQuery(query);
+        Assert.assertEquals(exp, res);
+    }
+
+}

--- a/src/integration/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjaxTest.java
+++ b/src/integration/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjaxTest.java
@@ -39,8 +39,14 @@ public class ModAnodeAjaxTest {
         }
     }
     @Test
-    public void testBasicUsageCEDData () throws IOException {
-        String query = "?start=2021-12-15&end=2021-12-17&timeUnit=day";
+    public void testBasicUsageCEDData () throws IOException, ParseException {
+        String d1 = "2021-12-15";
+        String d2 = "2021-12-16";
+        String d3 = "2021-12-17";
+        Date date1 = DateUtil.parseDateStringYMD(d1);
+        Date date2 = DateUtil.parseDateStringYMD(d2);
+        Date date3 = DateUtil.parseDateStringYMD(d3);
+        String query = "?start=" + d1 + "&end=" + d3 + "&timeUnit=day";
         String expString = "{" +
                 "\"labels\":[\"Injector\",\"North\",\"South\",\"Total\"]," +
                 "\"data\":[" +
@@ -55,7 +61,15 @@ public class ModAnodeAjaxTest {
             exp = reader.readObject();
         }
 
+        // Check without cache
+        clearCache(date1);
+        clearCache(date2);
+        clearCache(date3);
         JsonObject res = makeQuery(query);
+        Assert.assertEquals(exp, res);
+
+        // Check with cache
+        res = makeQuery(query);
         Assert.assertEquals(exp, res);
     }
 
@@ -63,7 +77,6 @@ public class ModAnodeAjaxTest {
     public void testBasicUsageMYAData () throws IOException, ParseException {
         String d = "2022-03-15";
         Date date = DateUtil.parseDateStringYMD(d);
-        clearCache(date);
         String query = "?start=" + d + "&end=" + d + "&timeUnit=day";
         String expString = "{" +
                 "\"labels\":[\"Injector\",\"North\",\"South\",\"Total\",\"Unknown\"]," +
@@ -81,6 +94,7 @@ public class ModAnodeAjaxTest {
         }
 
         // Check without the cache
+        clearCache(date);
         JsonObject res = makeQuery(query);
         Assert.assertEquals(exp, res);
 

--- a/src/main/java/org/jlab/rfd/business/service/CavityService.java
+++ b/src/main/java/org/jlab/rfd/business/service/CavityService.java
@@ -664,8 +664,8 @@ public class CavityService {
 
         Map<Date, Set<CavityDataPoint>> cacheData = this.readCache(dates);
         if (cacheData != null) {
+            CommentService cs = new CommentService();
             for (Date d : cacheData.keySet()) {
-                CommentService cs = new CommentService();
                 CommentFilter filter = new CommentFilter(null, null, null, null, DateUtil.getEndOfDay(d));
                 Map<String, SortedSet<Comment>> comments = cs.getCommentsByTopic(filter);
 

--- a/src/main/java/org/jlab/rfd/business/service/CavityService.java
+++ b/src/main/java/org/jlab/rfd/business/service/CavityService.java
@@ -662,6 +662,18 @@ public class CavityService {
             curr = cal.getTime();
         }
 
+        Map<Date, Set<CavityDataPoint>> cacheData = this.readCache(dates);
+        if (cacheData != null) {
+            for (Date d : cacheData.keySet()) {
+                CommentService cs = new CommentService();
+                CommentFilter filter = new CommentFilter(null, null, null, null, DateUtil.getEndOfDay(d));
+                Map<String, SortedSet<Comment>> comments = cs.getCommentsByTopic(filter);
+
+                span.put(d, this.createCommentResponseSet(cacheData.get(d), comments));
+            }
+            dates.removeAll(cacheData.keySet());
+        }
+
         // Randomize the order of the dates that are queried.  Consider multiple overlapping requests looking for
         // uncached data.  If they all go in order, then cache is never helpful and each query fetches the uncached
         // data.  Shuffling the order of requests is an easy way to minimize the chance of queries hitting the same

--- a/src/main/java/org/jlab/rfd/business/service/MyaService.java
+++ b/src/main/java/org/jlab/rfd/business/service/MyaService.java
@@ -57,7 +57,8 @@ public class MyaService {
      * future.
      * @throws IOException If problem arise while contacting the mya web service.
      */
-    public Map<String, BigDecimal> getCavityMyaData(Date timestamp, Map<String, String> name2Epics, Map<String, List<String>> postfixes) throws IOException {
+    public Map<String, BigDecimal> getCavityMyaData(Date timestamp, Map<String, String> name2Epics, Map<String,
+            List<String>> postfixes) throws IOException {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         if ( timestamp.after(new Date()) ) {
             return null;
@@ -68,7 +69,7 @@ public class MyaService {
         if (DateUtil.getDifferenceInDays(timestamp, new Date()) > 180) {
             deployment = "history";
         }
-        Map<String, BigDecimal> gsetData = new HashMap<>();
+        Map<String, BigDecimal> valueData = new HashMap<>();
         
         // Create a reverse lookup map.  name2Epics should be a 1:1 map
         Map<String, String> epics2Name = new HashMap<>();
@@ -119,10 +120,10 @@ public class MyaService {
                 if (sample.containsKey("v")) {
                     gset = sample.getJsonNumber("v").bigDecimalValue();
                 }
-                gsetData.put(epics2Name.get(epicsName), gset);
+                valueData.put(epics2Name.get(epicsName), gset);
             }
         }
-        return gsetData;
+        return valueData;
     }
 
     /**

--- a/src/main/java/org/jlab/rfd/model/CavityDataSpan.java
+++ b/src/main/java/org/jlab/rfd/model/CavityDataSpan.java
@@ -86,9 +86,10 @@ public class CavityDataSpan {
             JsonObjectBuilder sample = Json.createObjectBuilder();
             sample.add("date", sdf.format(d));
             JsonArrayBuilder cavities = Json.createArrayBuilder();
-
-            for (CavityDataPoint dp : dataSpan.get(d)) {
-                cavities.add(dp.toJson());
+            if (dataSpan.get(d) != null) {
+                for (CavityDataPoint dp : dataSpan.get(d)) {
+                    cavities.add(dp.toJson());
+                }
             }
             sample.add("cavities", cavities.build());
             data.add(sample.build());

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/CavityAjax.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/CavityAjax.java
@@ -76,7 +76,7 @@ public class CavityAjax extends HttpServlet {
             Date end = null;
             if (dates == null) {
                 try {
-                    startEnd = RequestParamUtil.processStartEnd(request, TimeUnit.WEEK, 4);
+                    startEnd = RequestParamUtil.processStartEnd(request, timeUnit, 4);
                     start = startEnd.get("start");
                     end = startEnd.get("end");
                 } catch (ParseException ex) {

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/CavityCache.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/CavityCache.java
@@ -39,10 +39,7 @@ public class CavityCache extends HttpServlet {
         }
 
         // Default to read action
-        System.out.println("Before " + action);
         action = action == null ? "read" : action;
-        System.out.println("After " + action);
-
         switch (action){
             case "read":
                 break;

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/CavityCache.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/CavityCache.java
@@ -2,6 +2,7 @@ package org.jlab.rfd.presentation.controller.ajax;
 
 import org.jlab.rfd.business.service.CavityService;
 import org.jlab.rfd.business.util.DateUtil;
+import org.jlab.rfd.model.CavityDataPoint;
 import org.jlab.rfd.model.CavityDataSpan;
 import org.jlab.rfd.model.CavityResponse;
 
@@ -74,9 +75,12 @@ public class CavityCache extends HttpServlet {
             }
         } else {
             try {
-                Set<CavityResponse> data = cs.createCommentResponseSet(cs.readCache(d), new HashMap<>());
+                Set<CavityDataPoint> cdps = cs.readCache(d);
                 CavityDataSpan span = new CavityDataSpan();
-                span.put(d, data);
+                if (cdps != null) {
+                    Set<CavityResponse> data = cs.createCommentResponseSet(cdps, new HashMap<>());
+                    span.put(d, data);
+                }
                 try (PrintWriter pw = response.getWriter()) {
                     String json = span.toJson().toString();
                     pw.write("{\"response\": \"Success\", \"data\": " + json + "}");

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjax.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjax.java
@@ -35,7 +35,6 @@ import org.jlab.rfd.presentation.util.DataFormatter;
 public class ModAnodeAjax extends HttpServlet {
     public static final Logger LOGGER = Logger.getLogger(ModAnodeAjax.class.getName());
     
-    // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
     /**
      * Handles the HTTP <code>GET</code> method.
      *
@@ -47,7 +46,7 @@ public class ModAnodeAjax extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        //LOGGER.log(Level.FINEST, "Received followig request parameters: {0}", request.getParameterMap().toString());
+        //LOGGER.log(Level.FINEST, "Received following request parameters: {0}", request.getParameterMap().toString());
         
         Map<String, Date> startEnd;
         Date start;
@@ -59,7 +58,7 @@ public class ModAnodeAjax extends HttpServlet {
             end = startEnd.get("end");
         } catch (ParseException ex) {
             LOGGER.log(Level.SEVERE, "Error parsing start/end attributes", ex);
-            throw new ServletException("Error parseing start/end", ex);
+            throw new ServletException("Error parsing start/end", ex);
         }
 
         String[] valid = {"flot"};
@@ -87,13 +86,10 @@ public class ModAnodeAjax extends HttpServlet {
         }
 
         SortedMap<Date, SortedMap<String, BigDecimal>> factoredData;
-        switch (factor) {
-            case "cmtype":
-                factoredData = span.getModAnodeCountByCMType(null);
-                break;
-            default:
-                factoredData = span.getModAnodeCountByLinac(true);
-                break;
+        if (factor.equals("cmtype")) {
+            factoredData = span.getModAnodeCountByCMType(null);
+        } else {
+            factoredData = span.getModAnodeCountByLinac(true);
         }
 
         PrintWriter pw = response.getWriter();


### PR DESCRIPTION
This branch has code that implements a better cache querying strategy that gets multiple dates in a single query.  The old version made a query per date which resulted in a noticeable slowdown when querying data for many dates.

This also fixes a bug where mod anode voltage data can be unknown since we know query from MYA/EPICS and MYA may not have a value for a give date.