### PR TITLE
BigDecimal purge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN if [ -z "${CUSTOM_CRT_URL}" ] ; then echo "No custom cert needed"; else \
            && export OPTIONAL_CERT_ARG=--cert=/etc/ssl/certs/ca-certificates.crt \
     ; fi
 COPY . /app
-# TODO: What is OPTIONAL_CERT_ARG for?
 RUN cd /app && gradle build -x test --no-watch-fs $OPTIONAL_CERT_ARG
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ plugins {
 
 description "RF Dashboard app for CEBAF"
 group 'org.jlab'
-version '2.1.1'
-ext.releaseDate = 'July 30, 2023'
-ext.resourceNumber = '44'
+version '2.1.2'
+ext.releaseDate = 'Aug 1, 2023'
+ext.resourceNumber = '45'
 
 tasks.withType(JavaCompile) {
     options.release = 11

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ plugins {
 
 description "RF Dashboard app for CEBAF"
 group 'org.jlab'
-version '2.1.0'
+version '2.1.1'
 ext.releaseDate = 'July 30, 2023'
-ext.resourceNumber = '43'
+ext.resourceNumber = '44'
 
 tasks.withType(JavaCompile) {
     options.release = 11

--- a/deps.yml
+++ b/deps.yml
@@ -39,6 +39,7 @@ services:
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      # TLDR; You can't logout unless you set frontend to be your development hostname.
       # If localhost, then rfd server tries to connect to itself and finds no one listening.  Need to expose
       # keycloak port, and use dev system hostname to direct traffic to the proper system/port
       #KEYCLOAK_FRONTEND_HOSTNAME: <YOUR_SYSTEM_HOSTNAME>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       KEYCLOAK_RESOURCE: 'RFDashboard'
       KEYCLOAK_SECRET: 'yHi6W2raPmLvPXoxqMA7VWbLAA2WN0eB'
       KEYCLOAK_BACKEND_SERVER_URL: 'http://keycloak:8080'
+      # TLDR; You can't logout unless you set frontend to be your development hostname.
       # If localhost, then rfd server tries to connect to itself and finds no one listening.  Need to expose
       # keycloak port, and use dev system hostname to direct traffic to the proper system/port
       # KEYCLOAK_FRONTEND_SERVER_URL: 'http://<hostname>:8081'

--- a/src/integration/java/org/jlab/rfd/presentation/controller/ajax/CavityCacheTest.java
+++ b/src/integration/java/org/jlab/rfd/presentation/controller/ajax/CavityCacheTest.java
@@ -1,0 +1,162 @@
+package org.jlab.rfd.presentation.controller.ajax;
+
+import org.jlab.rfd.business.util.DateUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.json.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+public class CavityCacheTest {
+
+    private static final String CACHE_URL = "http://localhost:8080/RFDashboard/ajax/cavity-cache";
+    private static final String CAVITY_URL = "http://localhost:8080/RFDashboard/ajax/cavity";
+
+    private JsonObject primeCache(String date) throws IOException {
+        JsonObject json;
+        URL url = new URL(CAVITY_URL + "?date=" + date);
+        InputStream is = url.openStream();
+        try (JsonReader reader = Json.createReader(is)) {
+            json = reader.readObject();
+        }
+        return json;
+    }
+    private JsonObject clearCache(String date) throws IOException {
+        JsonObject json;
+        URL url = new URL(CACHE_URL + "?date=" + date + "&action=clear&secret=ayqs");
+        InputStream is = url.openStream();
+        try (JsonReader reader = Json.createReader(is)) {
+            json = reader.readObject();
+        }
+        return json;
+    }
+
+        private JsonObject makeQuery(String query) throws IOException {
+        JsonObject json;
+        URL url = new URL(CACHE_URL + query);
+        InputStream is = url.openStream();
+        try (JsonReader reader = Json.createReader(is)) {
+            json = reader.readObject();
+        }
+        return json;
+    }
+    @Test
+    public void testBasicUsageEmptyCache() throws IOException {
+        String dateString = "2022-03-15";
+        String expString = "{\n" +
+                "  \"response\": \"Success\",\n" +
+                "  \"data\": {\n" +
+                "    \"data\": [\n" +
+                "      \n" +
+                "    ]\n" +
+                "  }\n" +
+                "}";
+        JsonObject exp;
+        try(JsonReader reader = Json.createReader(new StringReader(expString))) {
+            exp = reader.readObject();
+        }
+
+        clearCache(dateString);
+        JsonObject result = makeQuery("?date="+dateString);
+        Assert.assertEquals(exp, result);
+    }
+
+    @Test
+    public void testBasicUsageFullCache() throws IOException {
+        String dateString = "2022-03-15";
+        // Full expected response is too long for string literal.  This is one of the cavities that should be received.
+        String expString = "{\"name\":\"2L03-7\",\"linac\":\"South\",\"gset\":5.55455,\"modAnodeVoltage_kv\":0.0," +
+                "\"odvh\":7.0,\"q0\":\"5.74E+09\",\"qExternal\":\"7.63E+06\",\"maxGset\":7.0,\"opsGsetMax\":\"\"," +
+                "\"tripOffset\":6.567,\"tripSlope\":1.499,\"length\":0.5,\"bypassed\":false,\"tunerBad\":false," +
+                "\"moduleType\":\"C25\",\"epicsName\":\"R237\"}";
+        JsonObject exp;
+        try(JsonReader reader = Json.createReader(new StringReader(expString))) {
+            exp = reader.readObject();
+        }
+
+        primeCache(dateString);
+        JsonObject result = makeQuery("?date="+dateString);
+        // The response string literal is too big, so we can't just compare JsonObject.  Instead, check a few key aspects.
+        Assert.assertEquals("Success", result.getString("response"));
+        Assert.assertEquals(1, result.getJsonObject("data").getJsonArray("data").size());
+        Assert.assertEquals(418, result.getJsonObject("data").getJsonArray("data")
+                .getJsonObject(0).getJsonArray("cavities").size());
+
+        // Check that the response has the cavity we want and that the cavity has the data we expect.
+        boolean found = false;
+        JsonArray cavities = result.getJsonObject("data").getJsonArray("data").getJsonObject(0).getJsonArray("cavities");
+        for(int i = 0; i < cavities.size(); i++) {
+            JsonObject cavity = cavities.getJsonObject(i);
+            if (cavity.get("name") != null && cavity.getString("name").equals("2L03-7")) {
+                Assert.assertEquals(exp, cavity);
+                found = true;
+            }
+        }
+        Assert.assertTrue(found);
+
+    }
+
+    @Test
+    public void testLargeQuery() throws ParseException, IOException {
+        // The internal SQL query is now chunked to prevent it from growing too large.  This happens for queries
+        // larger than the set chunk size (around a year's worth of data).
+        String startString = "2020-01-01";
+        Calendar c = Calendar.getInstance();
+        c.setTime(DateUtil.parseDateStringYMD(startString));
+        Date start = c.getTime();
+        int numDates = 400;
+
+        List<Date> dateList = new ArrayList<>();
+        Date curr = start;
+        dateList.add(start);
+        for (int i = 1; i < numDates; i++) {
+            c.add(Calendar.DATE, 1);
+            curr = c.getTime();
+            dateList.add(curr);
+        }
+        String middleString = "2021-02-02"; // Should be after the chunk break.  No guarantee if someone changes code.
+        String endString = DateUtil.formatDateYMD(curr);
+
+        primeCache(startString);
+        primeCache(middleString);
+        primeCache(endString);
+        StringBuilder builder = new StringBuilder("?date=" + startString);
+        for(Date date : dateList) {
+            builder.append("&date=" + DateUtil.formatDateYMD(date));
+        }
+        String query = builder.toString();
+
+        JsonObject result = makeQuery(query);
+
+        // This is an array objects that each contain the data for a single date
+        JsonArray data = result.getJsonObject("data").getJsonArray("data");
+        Assert.assertTrue(data.size() >= 3);
+
+        // Check that we got what we know should be there.
+        boolean foundStart = false;
+        boolean foundMiddle = false;
+        boolean foundEnd = false;
+        for (int i = 0; i < data.size(); i++) {
+            if (data.getJsonObject(i).getString("date").equals(startString)) {
+                foundStart = true;
+            }
+            if (data.getJsonObject(i).getString("date").equals(middleString)) {
+                foundMiddle = true;
+            }
+            if (data.getJsonObject(i).getString("date").equals(endString)) {
+                foundEnd = true;
+            }
+        }
+        Assert.assertTrue(foundStart);
+        Assert.assertTrue(foundMiddle);
+        Assert.assertTrue(foundEnd);
+    }
+}

--- a/src/integration/java/org/jlab/rfd/presentation/controller/ajax/LinacAjaxTest.java
+++ b/src/integration/java/org/jlab/rfd/presentation/controller/ajax/LinacAjaxTest.java
@@ -1,0 +1,76 @@
+package org.jlab.rfd.presentation.controller.ajax;
+
+import org.jlab.rfd.business.util.DateUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Date;
+
+public class LinacAjaxTest {
+
+
+    private static final String QUERY_URL = "http://localhost:8080/RFDashboard/ajax/linac";
+    static final String CAVITY_CACHE_URL = "http://localhost:8080/RFDashboard/ajax/cavity-cache";
+    private JsonObject makeQuery(String query) throws IOException {
+        JsonObject json;
+        URL url = new URL(QUERY_URL + query);
+        InputStream is = url.openStream();
+
+        try (JsonReader reader = Json.createReader(is)) {
+            json = reader.readObject();
+        }
+        return json;
+    }
+
+    private void clearCache(Date date) throws IOException {
+        JsonObject json;
+        URL url = new URL(CAVITY_CACHE_URL + "?date=" + DateUtil.formatDateYMD(date) + "&secret=ayqs&action=clear");
+        InputStream is = url.openStream();
+        try (JsonReader reader = Json.createReader(is)) {
+            json = reader.readObject();
+        }
+        if (json.get("rowsCleared") == null) {
+            throw new RuntimeException(("Error processing cache clear response"));
+        }
+    }
+
+    @Test
+    public void testBasicUsage() throws ParseException, IOException {
+
+        String d = "2017-07-25";
+        Date date = DateUtil.parseDateStringYMD(d);
+
+        String expString = "{" +
+                "\"data\":[" +
+                "{\"date\":\"2017-07-25\"," +
+                "\"linacs\":{" +
+                "\"North\":" +
+                "{\"mav\":{\"1050\":\"1.373688\",\"1090\":\"5.620650\"}," +
+                "\"no_mav\":{\"1050\":\"1.225401\",\"1090\":\"4.712613\"}}," +
+                "\"South\":{" +
+                "\"mav\":{\"1050\":\"3.063313\",\"1090\":\"15.256875\"}," +
+                "\"no_mav\":{\"1050\":\"2.465463\",\"1090\":\"11.024100\"}" +
+                "}}}]}";
+        JsonObject exp;
+        try (JsonReader reader = Json.createReader(new StringReader(expString))) {
+            exp = reader.readObject();
+        }
+
+        // Test without the cache
+        clearCache(date);
+        JsonObject result = makeQuery("?date=2017-07-25");
+        Assert.assertEquals(exp, result);
+
+        // Test with the cache
+        result = makeQuery("?date=2017-07-25");
+        Assert.assertEquals(exp, result);
+    }
+}

--- a/src/main/java/org/jlab/rfd/business/service/LemService.java
+++ b/src/main/java/org/jlab/rfd/business/service/LemService.java
@@ -136,12 +136,12 @@ public class LemService {
     private LemRecord processResult(ResultSet rs, Date date, LinacName linac, int energyStart, int energyEnd, int energyStep) throws SQLException {
 
         long scanId = rs.getLong(1);
-        Map<Integer, BigDecimal> tripRates = new TreeMap<>();
+        Map<Integer, Double> tripRates = new TreeMap<>();
         int i = 4;
         for (int e = energyStart; e <= energyEnd; e = e + energyStep) {
             String tripRate = rs.getString(i);
             if (tripRate != null) {
-                tripRates.put(e, new BigDecimal(tripRate).setScale(10, RoundingMode.HALF_UP));
+                tripRates.put(e, Double.valueOf(tripRate));
             } else {
                 tripRates.put(e, null);
             }

--- a/src/main/java/org/jlab/rfd/business/service/ModAnodeHarvesterService.java
+++ b/src/main/java/org/jlab/rfd/business/service/ModAnodeHarvesterService.java
@@ -338,8 +338,6 @@ public class ModAnodeHarvesterService {
                     long scanId = rs.getLong("SCAN_ID");
                     Date ts = DATE_FORMATTER.parse(rs.getString("START_TIME"));
                     Date ed = DATE_FORMATTER.parse(rs.getString("EPICS_DATE"));
-                    pstmt.close();
-                    rs.close();
                     records.add(new ScanRecord(scanId, ts, ed));
                 }
                 pstmt.clearParameters();

--- a/src/main/java/org/jlab/rfd/business/service/ModAnodeHarvesterService.java
+++ b/src/main/java/org/jlab/rfd/business/service/ModAnodeHarvesterService.java
@@ -6,7 +6,6 @@
 package org.jlab.rfd.business.service;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -140,15 +139,21 @@ public class ModAnodeHarvesterService {
                 Map<LinacName, LinacRecord> records1090 = new HashMap<>();
                 while( rs.next() ) {
                     LinacName linac = LinacName.valueOf(rs.getString("LINAC"));
-                    BigDecimal energy = rs.getBigDecimal("ENERGY_MEV");
-                    BigDecimal trips = rs.getBigDecimal("TRIPS_PER_HOUR");
-                    if ( trips != null ) {
-                        trips = trips.setScale(6, RoundingMode.HALF_UP);
+                    Double energy = rs.getDouble("ENERGY_MEV");
+                    Double trips = rs.getDouble("TRIPS_PER_HOUR");
+                    if (rs.wasNull()) {
+                        trips = null;
                     }
-                    BigDecimal tripsNoMav = rs.getBigDecimal("TRIPS_PER_HOUR_NO_MAV");
-                    if ( tripsNoMav != null ) {
-                        tripsNoMav = tripsNoMav.setScale(6, RoundingMode.HALF_UP);
+//                    if ( trips != null ) {
+//                        trips = trips.setScale(6, RoundingMode.HALF_UP);
+//                    }
+                    Double tripsNoMav = rs.getDouble("TRIPS_PER_HOUR_NO_MAV");
+                    if (rs.wasNull()) {
+                        tripsNoMav = null;
                     }
+//                    if ( tripsNoMav != null ) {
+//                        tripsNoMav = tripsNoMav.setScale(6, RoundingMode.HALF_UP);
+//                    }
 
                     LinacRecord record = new LinacRecord(sr.getTimestamp(), sr.getEpicsDate(), linac, energy, trips, tripsNoMav);
                     switch (record.getEnergy().intValue()) {

--- a/src/main/java/org/jlab/rfd/business/service/MyaService.java
+++ b/src/main/java/org/jlab/rfd/business/service/MyaService.java
@@ -7,7 +7,6 @@ package org.jlab.rfd.business.service;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigDecimal;
 import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -33,11 +32,11 @@ public class MyaService {
      * @param timestamp What date are we sampling the data for
      * @param name2Epics A map of cavity name (CED) to EPICSName.  This is used to map results back to cavity name.
      * @param postfix The single postfix to be appended to every EPICSName
-     * @return A map of cavity names (CED) to BigDecimal values of the PVs at that time or null if timestamp is in the
+     * @return A map of cavity names (CED) to Double values of the PVs at that time or null if timestamp is in the
      * future.
      * @throws IOException If problem arise while contacting the mya web service.
      */
-    public Map<String, BigDecimal> getCavityMyaData(Date timestamp, Map<String, String> name2Epics, String postfix) throws IOException {
+    public Map<String, Double> getCavityMyaData(Date timestamp, Map<String, String> name2Epics, String postfix) throws IOException {
         Map<String, List<String>> postfixes = new HashMap<>();
         for (String name : name2Epics.keySet()) {
             postfixes.putIfAbsent(name, new ArrayList<>());
@@ -53,11 +52,11 @@ public class MyaService {
      * @param timestamp What date are we sampling the data for
      * @param name2Epics A map of cavity name (CED) to EPICSName.  This is used to map results back to cavity name.
      * @param postfixes A map of cavity name (CED) to a list of PV postfixes that are to be queried.
-     * @return A map of cavity names (CED) to BigDecimal values of the PVs at that time or null if timestamp is in the
+     * @return A map of cavity names (CED) to Double values of the PVs at that time or null if timestamp is in the
      * future.
      * @throws IOException If problem arise while contacting the mya web service.
      */
-    public Map<String, BigDecimal> getCavityMyaData(Date timestamp, Map<String, String> name2Epics, Map<String,
+    public Map<String, Double> getCavityMyaData(Date timestamp, Map<String, String> name2Epics, Map<String,
             List<String>> postfixes) throws IOException {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         if ( timestamp.after(new Date()) ) {
@@ -69,7 +68,7 @@ public class MyaService {
         if (DateUtil.getDifferenceInDays(timestamp, new Date()) > 180) {
             deployment = "history";
         }
-        Map<String, BigDecimal> valueData = new HashMap<>();
+        Map<String, Double> valueData = new HashMap<>();
         
         // Create a reverse lookup map.  name2Epics should be a 1:1 map
         Map<String, String> epics2Name = new HashMap<>();
@@ -114,13 +113,13 @@ public class MyaService {
                     throw new IOException("Error querying PV '" + pv + "'.  " + chan.getJsonObject(pv).getString("error"));
                 }
                 String epicsName = pv.substring(0, 4);
-                BigDecimal gset = null;
+                Double value = null;
                 JsonObject sample = chan.getJsonObject(pv).getJsonArray("data").get(0).asJsonObject();
 
                 if (sample.containsKey("v")) {
-                    gset = sample.getJsonNumber("v").bigDecimalValue();
+                    value = sample.getJsonNumber("v").doubleValue();
                 }
-                valueData.put(epics2Name.get(epicsName), gset);
+                valueData.put(epics2Name.get(epicsName), value);
             }
         }
         return valueData;

--- a/src/main/java/org/jlab/rfd/business/util/MathUtil.java
+++ b/src/main/java/org/jlab/rfd/business/util/MathUtil.java
@@ -7,8 +7,6 @@ package org.jlab.rfd.business.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.MathContext;
-import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,9 +20,9 @@ public class MathUtil {
 
     // Check each value to the following value.  If the following value is greater, return false.  If no comparison returns false,
     // then the array must be sorted.
-    public static final boolean isSorted(BigDecimal[] nums) {
+    public static final boolean isSorted(Double[] nums) {
         for ( int i = 0; i < nums.length-1; i++ ) {
-            if ( nums[i].compareTo(nums[i+1]) == 1 ) {
+            if ( nums[i] < nums[i+1] ) {
                 return false;
             }
         }
@@ -33,17 +31,17 @@ public class MathUtil {
     
     // Shamelessly stolen from www.java2s.com/Code/Java/Collections-Data-Structure/LinearInterpolation.htm
     // Added a MathContext to the only divide operation in this method.  Can cause exception without specified rounding, scale.
-    public static final BigDecimal[] interpLinear(BigDecimal[] x, BigDecimal[] y, BigDecimal[] xi) {
+    public static final Double[] interpLinear(Double[] x, Double[] y, Double[] xi) {
         if (x.length != y.length) {
             throw new IllegalArgumentException("X and Y must be the same length");
         }
         if (x.length == 1) {
             throw new IllegalArgumentException("X must contain more than one value");
         }
-        BigDecimal[] dx = new BigDecimal[x.length - 1];
-        BigDecimal[] dy = new BigDecimal[x.length - 1];
-        BigDecimal[] slope = new BigDecimal[x.length - 1];
-        BigDecimal[] intercept = new BigDecimal[x.length - 1];
+        Double[] dx = new Double[x.length - 1];
+        Double[] dy = new Double[x.length - 1];
+        Double[] slope = new Double[x.length - 1];
+        Double[] intercept = new Double[x.length - 1];
 
         // Calculate the line equation (i.e. slope and intercept) between each point
         BigInteger zero = new BigInteger("0");
@@ -51,38 +49,37 @@ public class MathUtil {
 
         for (int i = 0; i < x.length - 1; i++) {
             //dx[i] = x[i + 1] - x[i];
-            dx[i] = x[i + 1].subtract(x[i]);
-            if (dx[i].equals(new BigDecimal(zero, dx[i].scale()))) {
+            dx[i] = x[i + 1] - x[i];
+            if (dx[i] > -1E-6 && dx[i] < 1E-6) {
                 throw new IllegalArgumentException("X must be montotonic. A duplicate " + "x-value was found");
             }
-            if (dx[i].signum() < 0) {
+            if (dx[i] < 0) {
                 LOGGER.log(Level.WARNING, "X must be sorted.");
                 LOGGER.log(Level.FINEST, "x = {0}", toLogString(x));
                 LOGGER.log(Level.FINEST, "dx = {0}", toLogString(dx));
                 throw new IllegalArgumentException("X must be sorted");
             }
             //dy[i] = y[i + 1] - y[i];
-            dy[i] = y[i + 1].subtract(y[i]);
+            dy[i] = y[i + 1] -y[i];
             //slope[i] = dy[i] / dx[i];
-            MathContext mc = new MathContext(Math.max(dy[i].scale(), dx[i].scale()), RoundingMode.HALF_UP);
-            slope[i] = dy[i].divide(dx[i], mc);
+            slope[i] = dy[i] / dx[i];
             //intercept[i] = y[i] - x[i] * slope[i];
-            intercept[i] = x[i].multiply(slope[i]).subtract(y[i]).multiply(minusOne);
+            intercept[i] = y[i] - (x[i] * slope[i]);
             //intercept[i] = y[i].subtract(x[i]).multiply(slope[i]);
         }
 
         // Perform the interpolation here
-        BigDecimal[] yi = new BigDecimal[xi.length];
+        Double[] yi = new Double[xi.length];
         for (int i = 0; i < xi.length; i++) {
             //if ((xi[i] > x[x.length - 1]) || (xi[i] < x[0])) {
-            if (xi[i].compareTo(x[x.length - 1]) > 0 || xi[i].compareTo(x[0]) < 0) {
+            if (xi[i] > x[x.length - 1] || xi[i] < x[0]) {
                 yi[i] = null; // same as NaN
             } else {
                 int loc = Arrays.binarySearch(x, xi[i]);
                 if (loc < -1) {
                     loc = -loc - 2;
                     //yi[i] = slope[loc] * xi[i] + intercept[loc];
-                    yi[i] = slope[loc].multiply(xi[i]).add(intercept[loc]);
+                    yi[i] = slope[loc] * xi[i] + intercept[loc];
                 } else {
                     yi[i] = y[loc];
                 }
@@ -93,9 +90,9 @@ public class MathUtil {
     }
 
     // Convenience function for printing out BigDecimalArrays
-    private static String toLogString(BigDecimal[] nums) {
+    private static String toLogString(Double[] nums) {
         String msg = "[";
-        for (BigDecimal n : nums) {
+        for (Double n : nums) {
             if (n != null) {
                 msg += ", " + n.toString();
             } else {

--- a/src/main/java/org/jlab/rfd/model/CavityDataPoint.java
+++ b/src/main/java/org/jlab/rfd/model/CavityDataPoint.java
@@ -6,7 +6,6 @@
 package org.jlab.rfd.model;
 
 import org.jlab.rfd.model.ModAnodeHarvester.CavityGsetData;
-import java.math.BigDecimal;
 import java.util.Date;
 import java.util.logging.Logger;
 import java.util.logging.Level;
@@ -16,12 +15,12 @@ import javax.json.JsonObjectBuilder;
 import org.jlab.rfd.business.util.CebafNames;
 
 /**
- * This class represents a the available data about a cavity at a specific point
+ * This class represents the available data about a cavity at a specific point
  * in time. This includes MYA data like cavity GSET, CED data like
  * ModAnodeVoltage or CryoModule ModuleType, or custom database data like the
  * ModAnodeHarvester data that shows the difference in trips and GSET with and
  * without any CED ModAnode voltages. Note: This object contains historical data that can easily be cached and doesn't
- * change once set.  CavityResponse should be used to respond to queries of cavity data, espeically if the response 
+ * change once set.  CavityResponse should be used to respond to queries of cavity data, especially if the response
  * is a value that needs to vary over a date (since the cache is effectively keyed on date).
  *
  * @author adamc
@@ -35,19 +34,19 @@ public class CavityDataPoint implements Cloneable {
     private final String epicsName;
     private final String zoneName;
     private final String epicsZoneName;
-    private final BigDecimal modAnodeVoltage;
+    private final Double modAnodeVoltage;
     private final CryomoduleType cryomoduleType;
     private final LinacName linacName;
-    private final BigDecimal gset;
+    private final Double gset;
     private final CavityGsetData modAnodeHarvesterGsetData;
-    private final BigDecimal odvh;
+    private final Double odvh;
     private final String q0;
     private final String qExternal;
-    private final BigDecimal maxGset;
-    private final BigDecimal opsGsetMax;
-    private final BigDecimal tripOffset;
-    private final BigDecimal tripSlope;
-    private final BigDecimal length;
+    private final Double maxGset;
+    private final Double opsGsetMax;
+    private final Double tripOffset;
+    private final Double tripSlope;
+    private final Double length;
     private final boolean bypassed;
     private final boolean tunerBad;
 
@@ -80,9 +79,9 @@ public class CavityDataPoint implements Cloneable {
     }
 
     public CavityDataPoint(Date timestamp, String cavityName, CryomoduleType cryomoduleType,
-            BigDecimal modAnodeVoltage, String epicsName, BigDecimal gset, BigDecimal odvh,
-            String q0, String qExternal, BigDecimal maxGset, BigDecimal opsGsetMax, BigDecimal tripOffset, BigDecimal tripSlope,
-            BigDecimal length, CavityGsetData modAnodeHarvesterGsetData, boolean bypassed, boolean tunerBad) {
+            Double modAnodeVoltage, String epicsName, Double gset, Double odvh,
+            String q0, String qExternal, Double maxGset, Double opsGsetMax, Double tripOffset, Double tripSlope,
+            Double length, CavityGsetData modAnodeHarvesterGsetData, boolean bypassed, boolean tunerBad) {
 
         if (!cavityName.matches("\\dL\\d\\d-\\d")) {
             LOGGER.log(Level.SEVERE, "Improper cavity name format - {0}", cavityName);
@@ -127,27 +126,27 @@ public class CavityDataPoint implements Cloneable {
         return qExternal;
     }
 
-    public BigDecimal getMaxGset() {
+    public Double getMaxGset() {
         return maxGset;
     }
 
-    public BigDecimal getOpsGsetMax() {
+    public Double getOpsGsetMax() {
         return opsGsetMax;
     }
 
-    public BigDecimal getTripOffset() {
+    public Double getTripOffset() {
         return tripOffset;
     }
 
-    public BigDecimal getTripSlope() {
+    public Double getTripSlope() {
         return tripSlope;
     }
 
-    public BigDecimal getLength() {
+    public Double getLength() {
         return length;
     }
 
-    public BigDecimal getOdvh() {
+    public Double getOdvh() {
         return odvh;
     }
 
@@ -167,7 +166,7 @@ public class CavityDataPoint implements Cloneable {
         return linacName;
     }
 
-    public BigDecimal getGset() {
+    public Double getGset() {
         return gset;
     }
 
@@ -175,7 +174,7 @@ public class CavityDataPoint implements Cloneable {
         return epicsName;
     }
 
-    public BigDecimal getModAnodeVoltage() {
+    public Double getModAnodeVoltage() {
         return modAnodeVoltage;
     }
 
@@ -196,17 +195,17 @@ public class CavityDataPoint implements Cloneable {
         cavBuilder.add("name", cavityName).add("linac", linacName.toString());
         // The json builder throws an exception on Null or Double.NaN.  This seemed like the smartest way to handle it.
         if (gset != null) {
-            cavBuilder.add("gset", gset.doubleValue());
+            cavBuilder.add("gset", gset);
         } else {
             cavBuilder.add("gset", "");
         }
         if (modAnodeVoltage != null) {
-            cavBuilder.add("modAnodeVoltage_kv", modAnodeVoltage.doubleValue());
+            cavBuilder.add("modAnodeVoltage_kv", modAnodeVoltage);
         } else {
             cavBuilder.add("modAnodeVoltage_kv", "");
         }
         if (odvh != null) {
-            cavBuilder.add("odvh", odvh.doubleValue());
+            cavBuilder.add("odvh", odvh);
         } else {
             cavBuilder.add("odvh", "");
         }
@@ -222,27 +221,27 @@ public class CavityDataPoint implements Cloneable {
             cavBuilder.add("qExternal", "");
         }
         if (maxGset != null) {
-            cavBuilder.add("maxGset", maxGset.doubleValue());
+            cavBuilder.add("maxGset", maxGset);
         } else {
             cavBuilder.add("maxGset", "");
         }
         if (opsGsetMax != null) {
-            cavBuilder.add("opsGsetMax", opsGsetMax.doubleValue());
+            cavBuilder.add("opsGsetMax", opsGsetMax);
         } else {
             cavBuilder.add("opsGsetMax", "");
         }
         if (tripOffset != null) {
-            cavBuilder.add("tripOffset", tripOffset.doubleValue());
+            cavBuilder.add("tripOffset", tripOffset);
         } else {
             cavBuilder.add("tripOffset", "");
         }
         if (tripSlope != null) {
-            cavBuilder.add("tripSlope", tripSlope.doubleValue());
+            cavBuilder.add("tripSlope", tripSlope);
         } else {
             cavBuilder.add("tripSlope", "");
         }
         if (length!= null) {
-            cavBuilder.add("length", length.doubleValue());
+            cavBuilder.add("length", length);
         } else {
             cavBuilder.add("length", "");
         }

--- a/src/main/java/org/jlab/rfd/model/CavityDataSpan.java
+++ b/src/main/java/org/jlab/rfd/model/CavityDataSpan.java
@@ -5,7 +5,6 @@
  */
 package org.jlab.rfd.model;
 
-import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import javax.json.Json;
@@ -108,19 +107,19 @@ public class CavityDataSpan {
      *
      * @return
      */
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getModAnodeCountByLinac(boolean includeInjector) {
-        SortedMap<Date, SortedMap<String, BigDecimal>> data = new TreeMap<>();
+    public SortedMap<Date, SortedMap<String, Integer>> getModAnodeCountByLinac(boolean includeInjector) {
+        SortedMap<Date, SortedMap<String, Integer>> data = new TreeMap<>();
 
-        SortedMap<String, BigDecimal> byLinac;
+        SortedMap<String, Integer> byLinac;
         int total;
         int unknown;
         for (Date date : (Set<Date>) dataSpan.keySet()) {
             byLinac = new TreeMap<>();
             if (includeInjector) {
-                byLinac.put(LinacName.Injector.toString(), new BigDecimal(0));
+                byLinac.put(LinacName.Injector.toString(), 0);
             }
-            byLinac.put(LinacName.North.toString(), new BigDecimal(0));
-            byLinac.put(LinacName.South.toString(), new BigDecimal(0));
+            byLinac.put(LinacName.North.toString(), 0);
+            byLinac.put(LinacName.South.toString(), 0);
             total = 0;
             unknown = 0;
 
@@ -130,23 +129,23 @@ public class CavityDataSpan {
                 }
                 if (cDP.getModAnodeVoltage() == null) {
                     unknown++;
-                } else if (cDP.getModAnodeVoltage().doubleValue() > 0) {
-                    byLinac.put(cDP.getLinacName().toString(), byLinac.get(cDP.getLinacName().toString()).add(new BigDecimal(1)));
+                } else if (cDP.getModAnodeVoltage() > 0) {
+                    byLinac.put(cDP.getLinacName().toString(), byLinac.get(cDP.getLinacName().toString()) + 1);
                     total++;
                 }
 
             }
-            byLinac.put(LinacName.Total.toString(), new BigDecimal(total));
+            byLinac.put(LinacName.Total.toString(), total);
             if (unknown > 0) {
-                byLinac.put("Unknown", new BigDecimal(unknown));
+                byLinac.put("Unknown", unknown);
             }
             data.put(date, byLinac);
         }
         return data;
     }
 
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getModAnodeCountByCMType(Map<String, String> typeMapper) {
-        SortedMap<Date, SortedMap<String, BigDecimal>> data = new TreeMap<>();
+    public SortedMap<Date, SortedMap<String, Integer>> getModAnodeCountByCMType(Map<String, String> typeMapper) {
+        SortedMap<Date, SortedMap<String, Integer>> data = new TreeMap<>();
 
         if (typeMapper == null) {
             typeMapper = new HashMap<>();
@@ -158,19 +157,19 @@ public class CavityDataSpan {
             typeMapper.put(CryomoduleType.C75.toString(), CryomoduleType.C75.toString());
         }
 
-        SortedMap<String, BigDecimal> byCMType;
+        SortedMap<String, Integer> byCMType;
         int total;
         int unknown;
         String CMType;
 
         for (Date date : dataSpan.keySet()) {
             byCMType = new TreeMap<>();
-            byCMType.put(typeMapper.get(CryomoduleType.C100.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C50.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C25.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.F100.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C75.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C50T.toString()), new BigDecimal(0));
+            byCMType.put(typeMapper.get(CryomoduleType.C100.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C50.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C25.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.F100.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C75.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C50T.toString()), 0);
             total = 0;
             unknown = 0;
 
@@ -178,7 +177,7 @@ public class CavityDataSpan {
 
                 if (cDP.getModAnodeVoltage() == null) {
                     unknown++;
-                } else if (cDP.getModAnodeVoltage().doubleValue() > 0) {
+                } else if (cDP.getModAnodeVoltage() > 0) {
                     if (cDP.getCryomoduleType().equals(CryomoduleType.C100)
                             || cDP.getCryomoduleType().equals(CryomoduleType.C50)
                             || cDP.getCryomoduleType().equals(CryomoduleType.C50T)
@@ -186,26 +185,26 @@ public class CavityDataSpan {
                             || cDP.getCryomoduleType().equals(CryomoduleType.F100)
                             || cDP.getCryomoduleType().equals(CryomoduleType.C25)) {
                         CMType = typeMapper.get(cDP.getCryomoduleType().toString());
-                        byCMType.put(CMType, byCMType.get(CMType).add(new BigDecimal(1)));
+                        byCMType.put(CMType, byCMType.get(CMType) + 1);
                         total++;
                     }
                 }
 
             }
-            byCMType.put(LinacName.Total.toString(), new BigDecimal(total));
+            byCMType.put(LinacName.Total.toString(), total);
             if (unknown > 0) {
-                byCMType.put("Unknown", new BigDecimal(unknown));
+                byCMType.put("Unknown", unknown);
             }
             data.put(date, byCMType);
         }
         return data;
     }
 
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getBypassedCountByCMType(Map<String, String> typeMapper){
+    public SortedMap<Date, SortedMap<String, Integer>> getBypassedCountByCMType(Map<String, String> typeMapper){
         return getBypassedCountByCMType(typeMapper, false);
     }
 
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getBypassedCountByCMType(Map<String, String> typeMapper,
+    public SortedMap<Date, SortedMap<String, Integer>> getBypassedCountByCMType(Map<String, String> typeMapper,
                                                                                    boolean includeInjector) {
 
         if (typeMapper == null) {
@@ -219,10 +218,10 @@ public class CavityDataSpan {
         }
 
         // We want C25, C50, C100, Total, Unknown.  Compare as strings unless both are C*.  Then compare the number.
-        SortedMap<Date, SortedMap<String, BigDecimal>> data = new TreeMap<>();
+        SortedMap<Date, SortedMap<String, Integer>> data = new TreeMap<>();
 
 
-        SortedMap<String, BigDecimal> byCMType;
+        SortedMap<String, Integer> byCMType;
         int total;
         int unknown;
         String CMType;
@@ -239,12 +238,12 @@ public class CavityDataSpan {
                     return o1.compareTo(o2);
                 }
             });
-            byCMType.put(typeMapper.get(CryomoduleType.C100.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C50.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C25.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.F100.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C75.toString()), new BigDecimal(0));
-            byCMType.put(typeMapper.get(CryomoduleType.C50T.toString()), new BigDecimal(0));
+            byCMType.put(typeMapper.get(CryomoduleType.C100.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C50.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C25.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.F100.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C75.toString()), 0);
+            byCMType.put(typeMapper.get(CryomoduleType.C50T.toString()), 0);
             total = 0;
             unknown = 0;
 
@@ -264,7 +263,7 @@ public class CavityDataSpan {
                     switch (bypassed) {
                         case 1:
                             CMType = cDP.getCryomoduleType().toString();
-                            byCMType.put(typeMapper.get(CMType), byCMType.get(typeMapper.get(CMType)).add(new BigDecimal(1)));
+                            byCMType.put(typeMapper.get(CMType), byCMType.get(typeMapper.get(CMType)) + 1);
                             total++;
                             break;
                         case 0:
@@ -278,33 +277,33 @@ public class CavityDataSpan {
                 }
             }
 
-            byCMType.put(LinacName.Total.toString(), new BigDecimal(total));
+            byCMType.put(LinacName.Total.toString(), total);
             if (unknown > 0) {
-                byCMType.put("Unknown", new BigDecimal(unknown));
+                byCMType.put("Unknown", unknown);
             }
             data.put(date, byCMType);
         }
         return data;
     }
 
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getBypassedCountByLinac() {
+    public SortedMap<Date, SortedMap<String, Integer>> getBypassedCountByLinac() {
         return getBypassedCountByLinac(false);
     }
 
 
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getBypassedCountByLinac(boolean includeInjector) {
-        SortedMap<Date, SortedMap<String, BigDecimal>> data = new TreeMap<>();
+    public SortedMap<Date, SortedMap<String, Integer>> getBypassedCountByLinac(boolean includeInjector) {
+        SortedMap<Date, SortedMap<String, Integer>> data = new TreeMap<>();
 
-        SortedMap<String, BigDecimal> byLinac;
+        SortedMap<String, Integer> byLinac;
         int total;
         int unknown;
         for (Date date : dataSpan.keySet()) {
             byLinac = new TreeMap<>();
             if (includeInjector) {
-                byLinac.put(LinacName.Injector.toString(), new BigDecimal(0));
+                byLinac.put(LinacName.Injector.toString(), 0);
             }
-            byLinac.put(LinacName.North.toString(), new BigDecimal(0));
-            byLinac.put(LinacName.South.toString(), new BigDecimal(0));
+            byLinac.put(LinacName.North.toString(), 0);
+            byLinac.put(LinacName.South.toString(), 0);
             total = 0;
             unknown = 0;
 
@@ -316,7 +315,7 @@ public class CavityDataSpan {
                 bypassed = checkCavityBypassed(cr);
                 switch(bypassed) {
                     case 1:
-                        byLinac.put(cr.getLinacName().toString(), byLinac.get(cr.getLinacName().toString()).add(new BigDecimal(1)));
+                        byLinac.put(cr.getLinacName().toString(), byLinac.get(cr.getLinacName().toString()) + 1);
                         total++;
                         break;
                     case 0:
@@ -328,10 +327,10 @@ public class CavityDataSpan {
                         throw new RuntimeException("Unexpected response from checkCavityBypassed");
                 }
             }
-            byLinac.put(LinacName.Total.toString(), new BigDecimal(total));
+            byLinac.put(LinacName.Total.toString(), total);
             data.put(date, byLinac);
             if (unknown > 0) {
-                byLinac.put("Unknown", new BigDecimal(unknown));
+                byLinac.put("Unknown", unknown);
             }
         }
         return data;
@@ -348,7 +347,7 @@ public class CavityDataSpan {
         int bypassed = 0;
         if (cr.isBypassed()) {
             bypassed  = 1;
-        } else if (cr.getGset() != null && cr.getGset().doubleValue() == 0) {
+        } else if (cr.getGset() != null && cr.getGset() == 0) {
             bypassed = 1;
         }
 
@@ -372,9 +371,9 @@ public class CavityDataSpan {
      * @return a map, keyed on date, where each date is a map of zone to energy
      * gain
      */
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getEnergyGainByZone(List<String> zones) {
-        SortedMap<Date, SortedMap<String, BigDecimal>> out = new TreeMap<>();
-        SortedMap<String, BigDecimal> byZone;
+    public SortedMap<Date, SortedMap<String, Double>> getEnergyGainByZone(List<String> zones) {
+        SortedMap<Date, SortedMap<String, Double>> out = new TreeMap<>();
+        SortedMap<String, Double> byZone;
 
         for (Date date : dataSpan.keySet()) {
             byZone = new TreeMap<>();
@@ -383,18 +382,18 @@ public class CavityDataSpan {
 
                 if (zones == null || zones.isEmpty() || zones.contains(zone)) {
                     if (!byZone.containsKey(zone)) {
-                        byZone.put(zone, BigDecimal.ZERO);
+                        byZone.put(zone, 0.0);
                     }
 
                     // GSET could be null if the control system was down, but the CED _should_ always have a length.
-                    BigDecimal gset = cr.getGset();
-                    BigDecimal cavEGain;
+                    Double gset = cr.getGset();
+                    double cavEGain;
                     if (gset == null) {
-                        cavEGain = BigDecimal.ZERO;
+                        cavEGain = 0.0;
                     } else {
-                        cavEGain = gset.multiply(cr.getLength());
+                        cavEGain = gset * cr.getLength();
                     }
-                    byZone.put(zone, byZone.get(zone).add(cavEGain));
+                    byZone.put(zone, byZone.get(zone) + cavEGain);
                 }
             }
             out.put(date, byZone);
@@ -412,7 +411,7 @@ public class CavityDataSpan {
      * @return a map, keyed on date, where each date is a map of zone to energy
      * gain
      */
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getEnergyGainByCMType(List<String> zones, Map<String, String> typeMapper) {
+    public SortedMap<Date, SortedMap<String, Double>> getEnergyGainByCMType(List<String> zones, Map<String, String> typeMapper) {
         if (typeMapper == null) {
             typeMapper = new HashMap<>();
             typeMapper.put("C100", "C100");
@@ -423,8 +422,8 @@ public class CavityDataSpan {
             typeMapper.put("C75", "C75");
             typeMapper.put("QTR", "QTR");
         }
-        SortedMap<Date, SortedMap<String, BigDecimal>> out = new TreeMap<>();
-        SortedMap<String, BigDecimal> byCMType;
+        SortedMap<Date, SortedMap<String, Double>> out = new TreeMap<>();
+        SortedMap<String, Double> byCMType;
 
         for (Date date : dataSpan.keySet()) {
             byCMType = new TreeMap<>();
@@ -434,18 +433,18 @@ public class CavityDataSpan {
 
                 if (zones == null || zones.isEmpty() || zones.contains(zone)) {
                     if (!byCMType.containsKey(cmType)) {
-                        byCMType.put(typeMapper.get(cmType), BigDecimal.ZERO);
+                        byCMType.put(typeMapper.get(cmType), 0.0);
                     }
 
                     // GSET could be null if the control system was down, but the CED _should_ always have a length.
-                    BigDecimal gset = cr.getGset();
-                    BigDecimal cavEGain;
+                    Double gset = cr.getGset();
+                    double cavEGain;
                     if (gset == null) {
-                        cavEGain = BigDecimal.ZERO;
+                        cavEGain = 0.0;
                     } else {
-                        cavEGain = gset.multiply(cr.getLength());
+                        cavEGain = gset * cr.getLength();
                     }
-                    byCMType.put(typeMapper.get(cmType), byCMType.get(typeMapper.get(cmType)).add(cavEGain));
+                    byCMType.put(typeMapper.get(cmType), byCMType.get(typeMapper.get(cmType)) + cavEGain);
                 }
             }
             out.put(date, byCMType);
@@ -463,9 +462,9 @@ public class CavityDataSpan {
      * @return a map, keyed on date, where each date is a map of zone to energy
      * gain
      */
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getEnergyGainByCavity(List<String> zones) {
-        SortedMap<Date, SortedMap<String, BigDecimal>> out = new TreeMap<>();
-        SortedMap<String, BigDecimal> byCavity;
+    public SortedMap<Date, SortedMap<String, Double>> getEnergyGainByCavity(List<String> zones) {
+        SortedMap<Date, SortedMap<String, Double>> out = new TreeMap<>();
+        SortedMap<String, Double> byCavity;
 
         for (Date date : dataSpan.keySet()) {
             byCavity = new TreeMap<>();
@@ -475,18 +474,18 @@ public class CavityDataSpan {
 
                 if (zones == null || zones.isEmpty() || zones.contains(zone)) {
                     if (!byCavity.containsKey(cavity)) {
-                        byCavity.put(cavity, BigDecimal.ZERO);
+                        byCavity.put(cavity, 0.0);
                     }
 
                     // GSET could be null if the control system was down, but the CED _should_ always have a length.
-                    BigDecimal gset = cr.getGset();
-                    BigDecimal cavEGain;
+                    Double gset = cr.getGset();
+                    double cavEGain;
                     if (gset == null) {
-                        cavEGain = BigDecimal.ZERO;
+                        cavEGain = 0.0;
                     } else {
-                        cavEGain = gset.multiply(cr.getLength());
+                        cavEGain = gset * cr.getLength();
                     }
-                    byCavity.put(cavity, byCavity.get(cavity).add(cavEGain));
+                    byCavity.put(cavity, byCavity.get(cavity) + cavEGain);
                 }
             }
             out.put(date, byCavity);

--- a/src/main/java/org/jlab/rfd/model/LemRecord.java
+++ b/src/main/java/org/jlab/rfd/model/LemRecord.java
@@ -5,7 +5,6 @@
  */
 package org.jlab.rfd.model;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -26,11 +25,11 @@ public class LemRecord {
     private static final Logger LOGGER = Logger.getLogger(LemRecord.class.getName());
 
     private final long scanId;
-    private final Map<Integer, BigDecimal> tripRates;
+    private final Map<Integer, Double> tripRates;
     private final Date timestamp;
     private final LinacName linac;
 
-    public LemRecord(long scanId, Date timestamp, LinacName linac, Map<Integer, BigDecimal> tripRates) {
+    public LemRecord(long scanId, Date timestamp, LinacName linac, Map<Integer, Double> tripRates) {
         this.scanId = scanId;
         this.timestamp = timestamp;
         this.linac = linac;
@@ -56,7 +55,7 @@ public class LemRecord {
     /**
      * @return Unmodifiable list of trip rates
      */
-    public Map<Integer, BigDecimal> getTripRates() {
+    public Map<Integer, Double> getTripRates() {
         return Collections.unmodifiableMap(tripRates);
     }
 
@@ -71,7 +70,7 @@ public class LemRecord {
         for(Integer e : tripRates.keySet()) {
             String tr = "";
             if (tripRates.get(e) != null) {
-                tr = tripRates.get(e).toPlainString();
+                tr = tripRates.get(e).toString();
             }
             trBuilder.add(e.toString(), tr);
         }

--- a/src/main/java/org/jlab/rfd/model/ModAnodeHarvester/LinacDataPoint.java
+++ b/src/main/java/org/jlab/rfd/model/ModAnodeHarvester/LinacDataPoint.java
@@ -5,7 +5,6 @@
  */
 package org.jlab.rfd.model.ModAnodeHarvester;
 
-import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -29,10 +28,10 @@ public class LinacDataPoint {
     private final LinacName linacName;
     private final Date timestamp;
     private final Date epicsDate;
-    private final BigDecimal trips1050;
-    private final BigDecimal trips1090;
-    private final BigDecimal tripsNoMav1050;
-    private final BigDecimal tripsNoMav1090;
+    private final Double trips1050;
+    private final Double trips1090;
+    private final Double tripsNoMav1050;
+    private final Double tripsNoMav1090;
 
     public LinacDataPoint(LinacRecord r1050, LinacRecord r1090) {
         String errString = "Error querying data";
@@ -88,19 +87,19 @@ public class LinacDataPoint {
         return epicsDate;
     }
 
-    public BigDecimal getTrips1050() {
+    public Double getTrips1050() {
         return trips1050;
     }
 
-    public BigDecimal getTrips1090() {
+    public Double getTrips1090() {
         return trips1090;
     }
 
-    public BigDecimal getTripsNoMav1050() {
+    public Double getTripsNoMav1050() {
         return tripsNoMav1050;
     }
 
-    public BigDecimal getTripsNoMav1090() {
+    public Double getTripsNoMav1090() {
         return tripsNoMav1090;
     }
     

--- a/src/main/java/org/jlab/rfd/model/ModAnodeHarvester/LinacDataSpan.java
+++ b/src/main/java/org/jlab/rfd/model/ModAnodeHarvester/LinacDataSpan.java
@@ -5,7 +5,6 @@
  */
 package org.jlab.rfd.model.ModAnodeHarvester;
 
-import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashSet;
@@ -73,12 +72,12 @@ public class LinacDataSpan {
                 if (ldp != null) {
                     linacs.add(ldp.getLinacName().toString(), Json.createObjectBuilder()
                             .add("mav", Json.createObjectBuilder()
-                                    .add("1050", ldp.getTrips1050() == null ? "" : ldp.getTrips1050().toPlainString())
-                                    .add("1090", ldp.getTrips1090() == null ? "" : ldp.getTrips1090().toPlainString())
+                                    .add("1050", ldp.getTrips1050() == null ? "" : String.format("%.6f", ldp.getTrips1050()))
+                                    .add("1090", ldp.getTrips1090() == null ? "" : String.format("%.6f", ldp.getTrips1090()))
                                     .build())
                             .add("no_mav", Json.createObjectBuilder()
-                                    .add("1050", ldp.getTripsNoMav1050() == null ? "" : ldp.getTripsNoMav1050().toPlainString())
-                                    .add("1090", ldp.getTripsNoMav1090() == null ? "" : ldp.getTripsNoMav1090().toPlainString())
+                                    .add("1050", ldp.getTripsNoMav1050() == null ? "" : String.format("%.6f", ldp.getTripsNoMav1050()))
+                                    .add("1090", ldp.getTripsNoMav1090() == null ? "" : String.format("%.6f", ldp.getTripsNoMav1090()))
                                     .build())
                             .build());
                 }
@@ -94,35 +93,35 @@ public class LinacDataSpan {
      *
      * @return
      */
-    public SortedMap<Date, SortedMap<String, BigDecimal>> getTripRates() {
+    public SortedMap<Date, SortedMap<String, Double>> getTripRates() {
 
         if (dataSpan.isEmpty()) {
             return null;
         }
 
-        SortedMap<Date, SortedMap<String, BigDecimal>> data = new TreeMap<>();
+        SortedMap<Date, SortedMap<String, Double>> data = new TreeMap<>();
         for (Date d : dataSpan.keySet()) {
-            TreeMap<String, BigDecimal> tmp = new TreeMap<>();
-            BigDecimal tnm1050 = BigDecimal.ZERO;
-            BigDecimal t1050 = BigDecimal.ZERO;
-            BigDecimal tnm1090 = BigDecimal.ZERO;
-            BigDecimal t1090 = BigDecimal.ZERO;
+            TreeMap<String, Double> tmp = new TreeMap<>();
+            Double tnm1050 = 0.0;
+            Double t1050 = 0.0;
+            Double tnm1090 = 0.0;
+            Double t1090 = 0.0;
 
             for (LinacDataPoint ldp : dataSpan.get(d)) {
 
                 // Need to make sure that both Linacs had non-null trip rates.  This indicates that both could be run at this energy and
                 // is a combined trip rate for CEBAF.
                 if (tnm1050 != null) {
-                    tnm1050 = ldp.getTripsNoMav1050() == null ? null : tnm1050.add(ldp.getTripsNoMav1050());
+                    tnm1050 = ldp.getTripsNoMav1050() == null ? null : tnm1050 + ldp.getTripsNoMav1050();
                 }
                 if (tnm1090 != null) {
-                    tnm1090 = ldp.getTripsNoMav1090() == null ? null : tnm1090.add(ldp.getTripsNoMav1090());
+                    tnm1090 = ldp.getTripsNoMav1090() == null ? null : tnm1090 + ldp.getTripsNoMav1090();
                 }
                 if (t1050 != null) {
-                    t1050 = ldp.getTrips1050() == null ? null : t1050.add(ldp.getTrips1050());
+                    t1050 = ldp.getTrips1050() == null ? null : t1050 + ldp.getTrips1050();
                 }
                 if (t1090 != null) {
-                    t1090 = ldp.getTrips1090() == null ? null : t1090.add(ldp.getTrips1090());
+                    t1090 = ldp.getTrips1090() == null ? null : t1090 + ldp.getTrips1090();
                 }
             }
 //            tmp.put("Total 1050 MeV No M.A.V.", tnm1050 == null ? BigDecimal.ZERO : tnm1050);

--- a/src/main/java/org/jlab/rfd/model/ModAnodeHarvester/LinacRecord.java
+++ b/src/main/java/org/jlab/rfd/model/ModAnodeHarvester/LinacRecord.java
@@ -16,9 +16,9 @@ import org.jlab.rfd.model.LinacName;
 public class LinacRecord {
     private final Date timestamp;
     private final Date epicsDate;
-    private final BigDecimal energy;
-    private final BigDecimal trips;
-    private final BigDecimal tripsNoMav;
+    private final Double energy;
+    private final Double trips;
+    private final Double tripsNoMav;
     private final LinacName linacName;
     
     /**
@@ -30,7 +30,7 @@ public class LinacRecord {
      * @param trips The number of trips per hour estimated by LEM when including the CED ModAnode values
      * @param tripsNoMav The number of trips per hour estimated by LEM when zeroing out the CED ModAnode values
      */
-    public LinacRecord(Date timestamp, Date epicsDate, LinacName linacName, BigDecimal energy, BigDecimal trips, BigDecimal tripsNoMav) {
+    public LinacRecord(Date timestamp, Date epicsDate, LinacName linacName, Double energy, Double trips, Double tripsNoMav) {
 
         this.linacName = linacName;
         this.timestamp = timestamp;
@@ -44,7 +44,7 @@ public class LinacRecord {
         return linacName;
     }
 
-    public BigDecimal getEnergy() {
+    public Double getEnergy() {
         return energy;
     }
 
@@ -56,11 +56,11 @@ public class LinacRecord {
         return epicsDate;
     }
 
-    public BigDecimal getTrips() {
+    public Double getTrips() {
         return trips;
     }
 
-    public BigDecimal getTripsNoMav() {
+    public Double getTripsNoMav() {
         return tripsNoMav;
     }    
 }

--- a/src/main/java/org/jlab/rfd/presentation/controller/Bypassed.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/Bypassed.java
@@ -169,8 +169,8 @@ public class Bypassed extends HttpServlet {
             typeMapper.put("C50T", "C50");
             typeMapper.put("C75", "C75");
 
-            bypassedCMType = DataFormatter.toFlotFromDateMap(cs.getCavityDataSpan(start, end, tu).getBypassedCountByCMType(typeMapper));
-            bypassedLinac = DataFormatter.toFlotFromDateMap(cs.getCavityDataSpan(start, end, tu).getBypassedCountByLinac());
+            bypassedCMType = DataFormatter.toFlotFromDateMapInt(cs.getCavityDataSpan(start, end, tu).getBypassedCountByCMType(typeMapper));
+            bypassedLinac = DataFormatter.toFlotFromDateMapInt(cs.getCavityDataSpan(start, end, tu).getBypassedCountByLinac());
             tableData = cs.getCavityDataSpan(date).toJson();
         } catch (ParseException | SQLException ex) {
             LOGGER.log(Level.WARNING, "Error querying cavity data", ex);

--- a/src/main/java/org/jlab/rfd/presentation/controller/EnergyReach.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/EnergyReach.java
@@ -6,7 +6,6 @@
 package org.jlab.rfd.presentation.controller;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
@@ -173,11 +172,11 @@ public class EnergyReach extends HttpServlet {
             // getLemSpan searches for energy reaches between the two dates, but requesters really want the number for the last day
             // which was almost certainly not done at exactly midnight the start of that day.
             Date endEffective = DateUtil.getNextDay(end);
-            SortedMap<Date, SortedMap<String, BigDecimal>> reach = ls.getLemSpan(start, endEffective).getEnergyReach();
+            SortedMap<Date, SortedMap<String, Double>> reach = ls.getLemSpan(start, endEffective).getEnergyReach();
 
             energyReach = DataFormatter.toFlotFromDateMap(reach);
             LemSpan lemSpan = ls.getLemSpan(diffEnd, DateUtil.getNextDay(diffEnd));
-            SortedMap<Integer, SortedMap<String, BigDecimal>> tripRates = lemSpan.getTripRateCurve(diffEnd);
+            SortedMap<Integer, SortedMap<String, Double>> tripRates = lemSpan.getTripRateCurve(diffEnd);
             dayScan = DataFormatter.toFlotFromIntMap(tripRates);
         } catch (ParseException | SQLException ex) {
             LOGGER.log(Level.WARNING, "Error querying LEM scan database", ex);

--- a/src/main/java/org/jlab/rfd/presentation/controller/ModAnode.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ModAnode.java
@@ -7,7 +7,6 @@ package org.jlab.rfd.presentation.controller;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.sql.SQLException;
 import java.text.ParseException;
@@ -156,8 +155,8 @@ public class ModAnode extends HttpServlet {
             typeMapper.put("C50", "C50");
             typeMapper.put("C50T", "C50");
             typeMapper.put("C75", "C75");
-            MAVCountCMType = DataFormatter.toFlotFromDateMap(s1.getModAnodeCountByCMType(typeMapper));
-            MAVCountLinac = DataFormatter.toFlotFromDateMap(s1.getModAnodeCountByLinac(false));
+            MAVCountCMType = DataFormatter.toFlotFromDateMapInt(s1.getModAnodeCountByCMType(typeMapper));
+            MAVCountLinac = DataFormatter.toFlotFromDateMapInt(s1.getModAnodeCountByLinac(false));
 
             List<Date> date = new ArrayList<>();
             date.add(tableDate);

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/BypassedAjax.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/BypassedAjax.java
@@ -88,7 +88,7 @@ public class BypassedAjax extends HttpServlet {
             throw new ServletException("Error in Bypassed Data", ex);
         }
         
-        SortedMap<Date, SortedMap<String, BigDecimal>> factoredData;
+        SortedMap<Date, SortedMap<String, Integer>> factoredData;
         switch (factor) {
             case "cmtype":
                 factoredData = span.getBypassedCountByCMType(null);
@@ -101,7 +101,7 @@ public class BypassedAjax extends HttpServlet {
         try {                
             if (out.equals("flot")) {
                 PrintWriter pw = response.getWriter();
-                JsonObject json = DataFormatter.toFlotFromDateMap(factoredData);
+                JsonObject json = DataFormatter.toFlotFromDateMapInt(factoredData);
                 response.setContentType("application/json");
                 pw.write(json.toString());
             }

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/LemScanAjax.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/LemScanAjax.java
@@ -7,7 +7,6 @@ package org.jlab.rfd.presentation.controller.ajax;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -103,7 +102,7 @@ public class LemScanAjax extends HttpServlet {
             try {
                 switch (out) {
                     case "flot": {
-                        SortedMap<Integer, SortedMap<String, BigDecimal>> tripRates = span.getTripRateCurve(start);
+                        SortedMap<Integer, SortedMap<String, Double>> tripRates = span.getTripRateCurve(start);
                         JsonObject json = DataFormatter.toFlotFromIntMap(tripRates);
                         response.setContentType("application/json");
                         pw.write(json.toString());
@@ -165,7 +164,7 @@ public class LemScanAjax extends HttpServlet {
             try {
                 switch (out) {
                     case "flot": {
-                        SortedMap<Date, SortedMap<String, BigDecimal>> reach = span.getEnergyReach();
+                        SortedMap<Date, SortedMap<String, Double>> reach = span.getEnergyReach();
                         JsonObject json;
                         if (reach == null) {
                             JsonObjectBuilder job = Json.createObjectBuilder();

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjax.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeAjax.java
@@ -7,7 +7,6 @@ package org.jlab.rfd.presentation.controller.ajax;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.Date;
@@ -85,7 +84,7 @@ public class ModAnodeAjax extends HttpServlet {
             throw new ServletException("Error in getting modAnode Data", ex);
         }
 
-        SortedMap<Date, SortedMap<String, BigDecimal>> factoredData;
+        SortedMap<Date, SortedMap<String, Integer>> factoredData;
         if (factor.equals("cmtype")) {
             factoredData = span.getModAnodeCountByCMType(null);
         } else {
@@ -95,7 +94,7 @@ public class ModAnodeAjax extends HttpServlet {
         PrintWriter pw = response.getWriter();
         try {
             if (out.equals("flot")) {
-                JsonObject json = DataFormatter.toFlotFromDateMap(factoredData);
+                JsonObject json = DataFormatter.toFlotFromDateMapInt(factoredData);
                 response.setContentType("application/json");
                 pw.write(json.toString());
             }

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeHarvester/LinacAjax.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeHarvester/LinacAjax.java
@@ -63,7 +63,7 @@ public class LinacAjax extends HttpServlet {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             LOGGER.log(Level.SEVERE, "Unsupported timeUnit value supplied {0}", timeUnit);
             response.setContentType("application/json");
-            pw.write("{error: 'Unsupported timeUnit value \"" + timeUnit + "\" supplied'}");
+            pw.write("{\"error\": \"Unsupported timeUnit value \"" + timeUnit + "\" supplied\"}");
             return;
         }
         
@@ -85,7 +85,7 @@ public class LinacAjax extends HttpServlet {
                 response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
                 LOGGER.log(Level.SEVERE, "Error.  No valid date requested");
                 response.setContentType("application/json");
-                pw.write("{error: 'Error. No valid date requested'}");
+                pw.write("{\"error\": \"Error. No valid date requested\"}");
                 return;
             }
         }
@@ -103,7 +103,7 @@ public class LinacAjax extends HttpServlet {
                 response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
                 LOGGER.log(Level.SEVERE, "Error parsing start/end attributes", ex);
                 response.setContentType("application/json");
-                pw.write("{error: 'Error parsing start/end parameters'}");
+                pw.write("{\"error\": \"Error parsing start/end parameters\"}");
                 return;
             }
         }
@@ -114,7 +114,7 @@ public class LinacAjax extends HttpServlet {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             LOGGER.log(Level.SEVERE, "Unsupported out value supplied {0}", out);
             response.setContentType("application/json");
-            pw.write("{error:\"Unsupported out value '" + out + "' supplied\"}");
+            pw.write("{\"error\": \"Unsupported out value '" + out + "' supplied\"}");
             return;            
         }
         
@@ -127,7 +127,7 @@ public class LinacAjax extends HttpServlet {
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 LOGGER.log(Level.SEVERE, "Error querying linac data service", ex);
                 response.setContentType("application/json");
-                pw.write("{error: 'Error querying linac data service'}");
+                pw.write("{\"error\": \"Error querying linac data service\"}");
                 return;
             }
         } else {
@@ -137,7 +137,7 @@ public class LinacAjax extends HttpServlet {
                 response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
                 LOGGER.log(Level.SEVERE, "Error querying linac data service", ex);
                 response.setContentType("application/json");
-                pw.write("{error: 'Error querying linac data service'}");
+                pw.write("{\"error\": \"Error querying linac data service\"}");
                 return;
             }
         }

--- a/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeHarvester/LinacAjax.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/ajax/ModAnodeHarvester/LinacAjax.java
@@ -7,7 +7,6 @@ package org.jlab.rfd.presentation.controller.ajax.ModAnodeHarvester;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -150,7 +149,7 @@ public class LinacAjax extends HttpServlet {
                 break;
             case "flot":
                 response.setContentType("application/json");
-                SortedMap<Date, SortedMap<String, BigDecimal>> factoredData = span.getTripRates();
+                SortedMap<Date, SortedMap<String, Double>> factoredData = span.getTripRates();
                 try {
                     JsonObject flot = DataFormatter.toFlotFromDateMap(factoredData);
                     pw.write(flot.toString());

--- a/src/main/java/org/jlab/rfd/presentation/controller/reports/EnergyGainHistory.java
+++ b/src/main/java/org/jlab/rfd/presentation/controller/reports/EnergyGainHistory.java
@@ -143,7 +143,7 @@ public class EnergyGainHistory extends HttpServlet {
             throw new ServletException("Error querying cryomodule data");
         }
         
-        SortedMap<Date, SortedMap<String, BigDecimal>> data;
+        SortedMap<Date, SortedMap<String, Double>> data;
         
         switch(by) {
             case "zone":

--- a/src/main/java/org/jlab/rfd/presentation/util/DataFormatter.java
+++ b/src/main/java/org/jlab/rfd/presentation/util/DataFormatter.java
@@ -6,7 +6,6 @@
 package org.jlab.rfd.presentation.util;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
@@ -95,14 +94,14 @@ public class DataFormatter {
      * @throws java.text.ParseException
      * @throws java.io.IOException
      */
-    public static JsonObject toFlotFromDateMap(SortedMap<Date, SortedMap<String, BigDecimal>> data) throws ParseException, IOException {
+    public static JsonObject toFlotFromDateMap(SortedMap<Date, SortedMap<String, Double>> data) throws ParseException, IOException {
 
         if (data == null) {
             return null;
         }
 
         // Javascript time format is like Unix Time, but in milliseconds.  the getTime() function gives you this by default.
-        Map<String, BigDecimal> temp;
+        Map<String, Double> temp;
         // The tree map keeps the series sorted in a reliable fashion.  Needed to coordinate the alignment of labels and data... well maybe not...
         SortedMap<String, JsonArrayBuilder> seriesBuilders = new TreeMap<>();
 
@@ -135,14 +134,104 @@ public class DataFormatter {
         return chartData;
     }
 
-    public static JsonObject toFlotFromIntMap(SortedMap<Integer, SortedMap<String, BigDecimal>> data) throws ParseException, IOException {
+    /**
+     * This function is designed to format a "By Linac", time series data
+     * structure as in JSON format.
+     *
+     * @param data A SortedMap keyed on data, with the value being a Map keyed
+     * on LinacName, valued on some BigDecimal
+     * @return A json object structured for direct consumption by Flot as a data
+     * object {series1: [[1,2],...], series2:...}
+     * @throws java.text.ParseException
+     * @throws java.io.IOException
+     */
+    public static JsonObject toFlotFromDateMapInt(SortedMap<Date, SortedMap<String, Integer>> data) throws ParseException, IOException {
 
         if (data == null) {
             return null;
         }
 
         // Javascript time format is like Unix Time, but in milliseconds.  the getTime() function gives you this by default.
-        Map<String, BigDecimal> temp;
+        Map<String, Integer> temp;
+        // The tree map keeps the series sorted in a reliable fashion.  Needed to coordinate the alignment of labels and data... well maybe not...
+        SortedMap<String, JsonArrayBuilder> seriesBuilders = new TreeMap<>();
+
+        for (Date curr : (Set<Date>) data.keySet()) {
+            temp = data.get(curr);
+            for (String seriesName : data.get(curr).keySet()) {
+                if (!seriesBuilders.containsKey(seriesName)) {
+                    seriesBuilders.put(seriesName, Json.createArrayBuilder());
+                }
+                seriesBuilders.get(seriesName)
+                        .add(Json.createArrayBuilder()
+                                .add(curr.getTime())
+                                //                                .add((temp.get(seriesName) != null) ? temp.get(seriesName).toString() : "null"));
+                                .add((temp.get(seriesName) != null) ? temp.get(seriesName).toString() : ""));
+            }
+        }
+
+        JsonArrayBuilder labelBuilder = Json.createArrayBuilder();
+        JsonArrayBuilder dataBuilder = Json.createArrayBuilder();
+        for (String seriesName : seriesBuilders.keySet()) {
+            labelBuilder.add(seriesName);
+            dataBuilder.add(seriesBuilders.get(seriesName).build());
+        }
+
+        JsonObject chartData = Json.createObjectBuilder()
+                .add("labels", labelBuilder.build())
+                .add("data", dataBuilder.build())
+                .build();
+
+        return chartData;
+    }
+
+    public static JsonObject toFlotFromIntMap(SortedMap<Integer, SortedMap<String, Double>> data) throws ParseException, IOException {
+
+        if (data == null) {
+            return null;
+        }
+
+        // Javascript time format is like Unix Time, but in milliseconds.  the getTime() function gives you this by default.
+        Map<String, Double> temp;
+        // The tree map keeps the series sorted in a reliable fashion.  Needed to coordinate the alignment of labels and data... well maybe not...
+        SortedMap<String, JsonArrayBuilder> seriesBuilders = new TreeMap<>();
+
+        for (Integer curr : (Set<Integer>) data.keySet()) {
+            temp = data.get(curr);
+            for (String seriesName : data.get(curr).keySet()) {
+                if (!seriesBuilders.containsKey(seriesName)) {
+                    seriesBuilders.put(seriesName, Json.createArrayBuilder());
+                }
+                seriesBuilders.get(seriesName)
+                        .add(Json.createArrayBuilder()
+                                .add(curr.toString())
+                                .add((temp.get(seriesName) != null) ? temp.get(seriesName).toString() : "null"));
+            }
+        }
+
+        JsonArrayBuilder labelBuilder = Json.createArrayBuilder();
+        JsonArrayBuilder dataBuilder = Json.createArrayBuilder();
+        for (String seriesName : seriesBuilders.keySet()) {
+            labelBuilder.add(seriesName);
+            dataBuilder.add(seriesBuilders.get(seriesName).build());
+        }
+
+        JsonObject chartData = Json.createObjectBuilder()
+                .add("labels", labelBuilder.build())
+                .add("data", dataBuilder.build())
+                .build();
+
+        return chartData;
+    }
+
+    public static JsonObject toFlotFromIntMapInt(SortedMap<Integer, SortedMap<String, Integer>> data) throws ParseException, IOException {
+
+        if (data == null) {
+            return null;
+        }
+
+        // Javascript time format is like Unix Time, but in milliseconds.  the getTime() function gives you this by default.
+        Map<String, Integer> temp;
         // The tree map keeps the series sorted in a reliable fashion.  Needed to coordinate the alignment of labels and data... well maybe not...
         SortedMap<String, JsonArrayBuilder> seriesBuilders = new TreeMap<>();
 


### PR DESCRIPTION
This update makes an attempt to limit how much memory is used for long queries by switching from BigDecimal objects to Double objects throughout.  In practice, it does not make much difference, but it does simplify the codebase as BigDecimals are typically only used when high precision is needed.  This is not the case and their use make reading the code more complicated.